### PR TITLE
Commentary improvements

### DIFF
--- a/shiny_app/child_health_tab.R
+++ b/shiny_app/child_health_tab.R
@@ -97,9 +97,9 @@ output$child_health_explorer <- renderUI({
    p("Information on the uptake of child health reviews that are routinely offered to all preschool children by Health Visitors has been included in this tool for the first time on 10 June 2020.", br(),
       "Child health reviews incorporate assessment of children's health, development, and wider wellbeing alongside provision of health promotion advice and parenting support.  Routine child health reviews help ensure that children’s health and development is progressing as expected for their age and stage, and allow any concerns to be addressed.  It is important that children continue to receive their routine health reviews during the Covid-19 pandemic.", br(),
       "On 10 June 2020, information has been provided on the coverage of the Health Visitor first visit, which is offered to children at 10-14 days of age. Children receive subsequent Health Visitor reviews at 6-8 weeks, 13-15 months, 27-30 month, and 4-5 years of age. ", br(),
-      "Coverage rates for the Health Visitor first visit have remained high during the pandemic. Coverage continues to exceed 90% among children who were due their review in March and early April. The recording of data on reviews undertaken by the reporting date will not be fully complete at this stage, particularly for the most recent cohorts, so coverage rates are slightly under-reported."
-      )
-     )
+      "Coverage rates for the Health Visitor first visit have remained high during the pandemic. Coverage continues to exceed 90% among children who were due their review in March and early April. The recording of data on reviews undertaken by the reporting date will not be fully complete at this stage, particularly for the most recent cohorts, so coverage rates are slightly under-reported."),
+   p(actionLink( "jump_childhealth", "View child health review data"))
+   )
  })
 
 ###############################################.

--- a/shiny_app/immunisation_tab.R
+++ b/shiny_app/immunisation_tab.R
@@ -129,8 +129,7 @@ output$download_imm_data <- downloadHandler(
 
 output$immun_commentary_section <- renderUI({
   tagList(h2("Immunisations - 3rd June 2020"), 
-          p("Link to", 
-            actionLink( "jump_immunisation", "'Immunisation' tab.")),
+          p("Link to",actionLink( "jump_immunisation", "Click to for 'Immunisation' data.")),
           p("Information on the uptake of ",
             tags$a(href="https://www.nhsinform.scot/healthy-living/immunisation","immunisations that 
                    are routinely offered to all preschool children",class="externallink"),
@@ -152,21 +151,8 @@ output$immun_commentary_section <- renderUI({
             immunisations given by the reporting date will not be fully complete at this stage, particularly for the most recent
             cohorts, so uptake rates are slightly under-reported. In addition, some children will receive the vaccine at a later age,
             for example due to missed or rescheduled appointments, so uptake rates are expected to continue to increase as children age 
-            (as shown in the 2019 data provided for comparison)."
-          ))
-})
-
-output$links <- renderText({
-  "<hr><br><span id='top' style='color: red;'>
-    <a href='#anchorid0'>Go to anchor0</a><br>
-    </span><br>
-    "
-})
-
-output$formattedText <- renderText({
-  "<hr><br><span id='anchorid0' style='color: red;'>Anchor0</span><br>
-    <a href='#top'>Go to Top</a><br>"
-})
+            (as shown in the 2019 data provided for comparison)."))
+  })
 
 
 #END

--- a/shiny_app/immunisation_tab.R
+++ b/shiny_app/immunisation_tab.R
@@ -1,6 +1,5 @@
 ##Server script for immunisations tab
 
-
 # Pop-up modal explaining source of data
 observeEvent(input$btn_immune_modal, 
              showModal(modalDialog(#RAPID ADMISSIONS MODAL
@@ -130,6 +129,8 @@ output$download_imm_data <- downloadHandler(
 
 output$immun_commentary_section <- renderUI({
   tagList(h2("Immunisations - 3rd June 2020"), 
+          p("Link to", 
+            actionLink( "jump_immunisation", "'Immunisation' tab.")),
           p("Information on the uptake of ",
             tags$a(href="https://www.nhsinform.scot/healthy-living/immunisation","immunisations that 
                    are routinely offered to all preschool children",class="externallink"),
@@ -153,6 +154,18 @@ output$immun_commentary_section <- renderUI({
             for example due to missed or rescheduled appointments, so uptake rates are expected to continue to increase as children age 
             (as shown in the 2019 data provided for comparison)."
           ))
+})
+
+output$links <- renderText({
+  "<hr><br><span id='top' style='color: red;'>
+    <a href='#anchorid0'>Go to anchor0</a><br>
+    </span><br>
+    "
+})
+
+output$formattedText <- renderText({
+  "<hr><br><span id='anchorid0' style='color: red;'>Anchor0</span><br>
+    <a href='#top'>Go to Top</a><br>"
 })
 
 

--- a/shiny_app/immunisation_tab.R
+++ b/shiny_app/immunisation_tab.R
@@ -128,8 +128,8 @@ output$download_imm_data <- downloadHandler(
 ###############################################.
 
 output$immun_commentary_section <- renderUI({
+  
   tagList(h2("Immunisations - 3rd June 2020"), 
-          p("Link to",actionLink( "jump_immunisation", "Click to for 'Immunisation' data.")),
           p("Information on the uptake of ",
             tags$a(href="https://www.nhsinform.scot/healthy-living/immunisation","immunisations that 
                    are routinely offered to all preschool children",class="externallink"),
@@ -151,7 +151,8 @@ output$immun_commentary_section <- renderUI({
             immunisations given by the reporting date will not be fully complete at this stage, particularly for the most recent
             cohorts, so uptake rates are slightly under-reported. In addition, some children will receive the vaccine at a later age,
             for example due to missed or rescheduled appointments, so uptake rates are expected to continue to increase as children age 
-            (as shown in the 2019 data provided for comparison)."))
+            (as shown in the 2019 data provided for comparison)."),
+          p(actionLink( "jump_immunisation", "View immunisation data")))
   })
 
 

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -15,6 +15,10 @@ function(input, output, session) {
   source(file.path("summary_tab.R"),  local = TRUE)$value
   
   ###############################################.
+  # Commentary tab  
+  source(file.path("commentary_tab.R"),  local = TRUE)$value
+  
+  ###############################################.
   ## Cardiovascular tab
   source(file.path("cardio_tab.R"),  local = TRUE)$value
   
@@ -32,6 +36,18 @@ function(input, output, session) {
   
   ###############################################.
   ## App navigation to move around tabs  
+  
+  #Table of content for commentary page
+  output$commentary_content <- renderText({
+    "<br><span id='commentary_TOC'>
+    <p>Use the links below to jump to a particular section of commentary</p>     
+    <a href='#anchor2006'>10th June 2020: Child health reviews</a><br>
+    <a href='#anchor0306'>3rd June 2020: Summary of trends</a><br>
+    <a href='#anchor0606_immune'>3rd June 2020: Immunisations</a><br>
+    </span><br>
+    "
+  })
+  
   observeEvent(input$jump_summary, {
     updateTabsetPanel(session, "intabset", selected = "summary")
   })
@@ -45,5 +61,9 @@ function(input, output, session) {
     updateTabsetPanel(session, "intabset", selected = "child")
   })
   
+    observeEvent(input$jump_childhealth, {
+      updateTabsetPanel(session, "intabset", selected = "child_health")
+    })  
+    
   
 } # server end

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -41,11 +41,15 @@ function(input, output, session) {
   output$commentary_content <- renderText({
     "<br><span id='commentary_TOC'>
     <p>Use the links below to jump to a particular section of commentary</p>     
-    <a href='#anchor2006'>10th June 2020: Child health reviews</a><br>
-    <a href='#anchor0306'>3rd June 2020: Summary of trends</a><br>
+    <a href='#anchor0306_summary'>3rd June 2020: Summary of trends</a><br>
     <a href='#anchor0606_immune'>3rd June 2020: Immunisations</a><br>
+    <a href='#anchor2006_chreviews'>10th June 2020: Child health reviews</a><br>
     </span><br>
     "
+  })
+  
+  observeEvent(input$jump_commentary, {
+    updateTabsetPanel(session, "intabset", selected = "comment")
   })
   
   observeEvent(input$jump_summary, {
@@ -54,16 +58,16 @@ function(input, output, session) {
   
   observeEvent(input$jump_table, {
     updateTabsetPanel(session, "intabset", selected = "table")
-
+    
   })
   
-    observeEvent(input$jump_immunisation, {
+  observeEvent(input$jump_immunisation, {
     updateTabsetPanel(session, "intabset", selected = "child")
   })
   
-    observeEvent(input$jump_childhealth, {
-      updateTabsetPanel(session, "intabset", selected = "child_health")
-    })  
+  observeEvent(input$jump_childhealth, {
+    updateTabsetPanel(session, "intabset", selected = "child_health")
+  })  
     
   
 } # server end

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -31,7 +31,7 @@ function(input, output, session) {
   source(file.path("data_tab.R"),  local = TRUE)$value
   
   ###############################################.
-  ## To move around tabs  
+  ## App navigation to move around tabs  
   observeEvent(input$jump_summary, {
     updateTabsetPanel(session, "intabset", selected = "summary")
   })
@@ -40,5 +40,10 @@ function(input, output, session) {
     updateTabsetPanel(session, "intabset", selected = "table")
 
   })
+  
+    observeEvent(input$jump_immunisation, {
+    updateTabsetPanel(session, "intabset", selected = "child")
+  })
+  
   
 } # server end

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -15,10 +15,6 @@ function(input, output, session) {
   source(file.path("summary_tab.R"),  local = TRUE)$value
   
   ###############################################.
-  # Commentary tab  
-  source(file.path("commentary_tab.R"),  local = TRUE)$value
-  
-  ###############################################.
   ## Cardiovascular tab
   source(file.path("cardio_tab.R"),  local = TRUE)$value
   

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -59,13 +59,19 @@ tabPanel("Introduction", icon = icon("info-circle"), value = "intro",
  tabPanel(title = "Commentary", icon = icon("list-ul"), value = "comment",
           mainPanel(width = 12,
                     p("This page provides general commentary around the information present within this tool. The commentary will refer to patterns and trends observed at a particular point in time and will be periodically updated."),
-                    htmlOutput("commentary_content"),
-                    uiOutput("child_comments"),
-                    HTML("<a href='#commentary_TOC'>Go to Top</a>"),
-                    uiOutput("summary_comment"),
-                    HTML("<a href='#commentary_TOC'>Go to Top</a>"),
-                    uiOutput("immun_commentary_section"),
-                    HTML("<a href='#commentary_TOC'>Go to Top</a>")
+                    htmlOutput("commentary_content"), #table of content for commentary page
+                    #Trend summary comments
+                    HTML("<span id='anchor0306_summary'></span>"), #ToC anchor postion
+                    uiOutput("summary_comment"), #commentary text
+                    HTML("<a href='#commentary_TOC'>Go to Top</a>"), #return to ToC
+                    #immunisation comments
+                    HTML("<span id='anchor0606_immune'></span>"), #ToC anchor postion
+                    uiOutput("immun_commentary_section"), #commentary text
+                    HTML("<a href='#commentary_TOC'>Go to Top</a>"), #return to ToC
+                    #Child health reviews
+                    HTML("<span id='anchor2006_chreviews'></span>"), #ToC anchor postion
+                    uiOutput("child_comments"),#commentary text
+                    HTML("<a href='#commentary_TOC'>Go to Top</a>") #return to ToC
           )#main panel bracket
  ), #tab panel
 ###############################################.
@@ -111,7 +117,9 @@ tabPanel(title = "Immunisations", icon = icon("syringe"), value = "child",
                                            direction = "vertical", justified = T))),
            column(4,actionButton("btn_immune_modal", "Data source: PHS SIRS", icon = icon('question-circle')),
                   fluidRow(br()),
-                  downloadButton('download_imm_data', 'Download data'))
+                  downloadButton('download_imm_data', 'Download data'),
+                  fluidRow(br()),
+                  actionLink("jump_commentary", "Data commentary"))
            #actionButton("browser", "Browser")
          ), #well panel
          mainPanel(width = 12,
@@ -135,7 +143,9 @@ tabPanel(title = "Child Health", icon = icon("child"), value = "child_health",
                                            direction = "vertical", justified = T))),
            column(4,actionButton("btn_child_modal", "Data source: CHSP-PS, SIRS", icon = icon('question-circle')),
                   fluidRow(br()),
-                  downloadButton("download_visit_data", "Download data"))
+                  downloadButton("download_visit_data", "Download data"),
+                  fluidRow(br()),
+                  actionLink("jump_commentary", "Data commentary"))
            #actionButton("browser", "Browser")
          ), #well panel
          mainPanel(width = 12,

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -58,11 +58,14 @@ tabPanel("Introduction", icon = icon("info-circle"), value = "intro",
 ###############################################.
  tabPanel(title = "Commentary", icon = icon("list-ul"), value = "comment",
           mainPanel(width = 12,
+                    p("This page provides general commentary around the information present within this tool. The commentary will refer to patterns and trends observed at a particular point in time and will be periodically updated."),
+                    htmlOutput("commentary_content"),
+                    uiOutput("child_comments"),
+                    HTML("<a href='#commentary_TOC'>Go to Top</a>"),
                     uiOutput("summary_comment"),
+                    HTML("<a href='#commentary_TOC'>Go to Top</a>"),
                     uiOutput("immun_commentary_section"),
-                    htmlOutput("links"),
-                    htmlOutput("formattedText"),
-                    uiOutput("child_comments")
+                    HTML("<a href='#commentary_TOC'>Go to Top</a>")
           )#main panel bracket
  ), #tab panel
 ###############################################.

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -60,6 +60,8 @@ tabPanel("Introduction", icon = icon("info-circle"), value = "intro",
           mainPanel(width = 12,
                     uiOutput("summary_comment"),
                     uiOutput("immun_commentary_section"),
+                    htmlOutput("links"),
+                    htmlOutput("formattedText"),
                     uiOutput("child_comments")
           )#main panel bracket
  ), #tab panel


### PR DESCRIPTION
This branch isn't finished yet but i'm sending it to you just to see if you like the way its looking.
I've adjusted the commentary page including a table of contents and links up and down the page plus also links to various tabs (there should be links back to the commentary from the immunisation and child health tab but only the immunisation one seems to work - I wondered if the observe event 'jump_commentary' can only be used once?)
I had wondered whether the commentary page should show the latest commentary first (ie reverse the current date order so child health review commentary would be first?)  I also though about using collapsible panels so you don't see a wall of text? 